### PR TITLE
Discord Updates

### DIFF
--- a/find_star/__main__.py
+++ b/find_star/__main__.py
@@ -2,7 +2,7 @@ import sys
 import json
 import logging
 
-from ._constants import VERBOSE
+from ._constants import VERBOSE, DEBUG
 
 if VERBOSE:
     logging.basicConfig(level=logging.DEBUG)
@@ -13,12 +13,12 @@ from .cli_arguments import cli_arguments
 
 from ._constants.discord import DISCORD_WEBHOOK_ENDPOINT
 
-if not DISCORD_WEBHOOK_ENDPOINT:
-    logging.error("Unset manditory variable: DISCORD_WEBHOOK_ENDPOINT")
+try:
+    message_handler = DiscordNotifier(DISCORD_WEBHOOK_ENDPOINT)
+except ValueError as _e:
+    logging.error("Failed to setup Discord message handler: %s", _e, stack_info=DEBUG)
     sys.exit(1)
 
-
-message_handler = DiscordNotifier(DISCORD_WEBHOOK_ENDPOINT)
 cli_args = cli_arguments()
 worlds = cli_args.pop("worlds")
 monitor = StarMonitor(
@@ -29,6 +29,7 @@ monitor = StarMonitor(
 )
 
 logging.debug("Running with settings: %r", cli_args)
+
 if cli_args["daemon"]:
     monitor.background_notify(message_handler)
 

--- a/find_star/_constants/discord.py
+++ b/find_star/_constants/discord.py
@@ -14,7 +14,7 @@ STARHUNTER_ROLE_ID = getenv("STARHUNTER_ROLE_ID", "StarHunters")
 
 DISCORD_MESSAGE_SPEC = """
 <@&%(role_id)s> T{tier:d} Star at '{loc:s}'
-> ~<t:{time:d}:R> by {scout:s} on [osrsportal.com](https://osrsportal.com/shooting-stars-tracker)'
+> ~<t:{time:%s}:R> by {scout:s} on [osrsportal.com](https://osrsportal.com/shooting-stars-tracker)'
 """.strip() % {
     "role_id": STARHUNTER_ROLE_ID
 }

--- a/find_star/_constants/discord.py
+++ b/find_star/_constants/discord.py
@@ -4,17 +4,41 @@ __all__ = (
     "DISCORD_WEBHOOK_ENDPOINT",
     "STARHUNTER_ROLE_ID",
     "DISCORD_MESSAGE_SPEC",
+    "DISCORD_MESSAGE_USERNAME",
+    "DISCORD_MESSAGE_EMBEDS",
+    "DISCORD_WEBHOOK_PAYLOAD",
 )
 
 DISCORD_WEBHOOK_ENDPOINT = getenv(
     "DISCORD_WEBHOOK_ENDPOINT",
 )
 
-STARHUNTER_ROLE_ID = getenv("STARHUNTER_ROLE_ID", "StarHunters")
+STARHUNTER_ROLE_ID = getenv("STARHUNTER_ROLE_ID")
+
+DISCORD_MESSAGE_USERNAME = "OSRS Star Watcher"
 
 DISCORD_MESSAGE_SPEC = """
-<@&%(role_id)s> T{tier:d} Star at '{loc:s}'
+T{tier:d} Star at '{loc:s}' in {world:d}
 > ~<t:{time:%s}:R> by {scout:s} on [osrsportal.com](https://osrsportal.com/shooting-stars-tracker)'
-""".strip() % {
-    "role_id": STARHUNTER_ROLE_ID
+""".strip()
+
+
+if STARHUNTER_ROLE_ID:
+    DISCORD_MESSAGE_SPEC = f"<@&{STARHUNTER_ROLE_ID}> " + DISCORD_MESSAGE_SPEC
+
+DISCORD_MESSAGE_EMBEDS = [
+    {
+        "title": "OSRS Star Tracker",
+        "url": "https://osrsportal.com/shooting-stars-tracker",
+        "footer": {
+            "text": "No affiliation",
+        },
+    },
+]
+
+DISCORD_WEBHOOK_PAYLOAD = {
+    "username": DISCORD_MESSAGE_USERNAME,
+    # the SPEC Will be formatted when posting to Discord
+    "content": DISCORD_MESSAGE_SPEC,
+    "embeds": DISCORD_MESSAGE_EMBEDS,
 }

--- a/find_star/_constants/discord.py
+++ b/find_star/_constants/discord.py
@@ -18,7 +18,7 @@ STARHUNTER_ROLE_ID = getenv("STARHUNTER_ROLE_ID")
 DISCORD_MESSAGE_USERNAME = "OSRS Star Watcher"
 
 DISCORD_MESSAGE_SPEC = """
-T{tier:d} Star at '{loc:s}' in {world:d}
+T{tier:d} Star at '{loc:s}' in W{world:d}
 > ~<t:{time:%s}:R> by {scout:s} on [osrsportal.com](https://osrsportal.com/shooting-stars-tracker)'
 """.strip()
 

--- a/find_star/discord/notifier.py
+++ b/find_star/discord/notifier.py
@@ -76,16 +76,13 @@ class DiscordNotifier:
     def __call__(self, __star_info: "Star") -> "requests.Response":
         """Send notification to Discord"""
         star = __star_info
-        _scout_time = star["time"]
-        star["time"] = round(_scout_time.timestamp())
         payload = copy(self.payload)
         payload["content"] = (
             # Format tempate message with star info
             payload["content"].format(**star)
         )
         if DEBUG:
-            logger.debug(
-                "Sending the following message to Discord:\n%r", payload)
+            logger.debug("Sending the following message to Discord:\n%r", payload)
         ret = requests.post(
             self.__endpoint,
             data=json.dumps(payload),
@@ -97,6 +94,9 @@ class DiscordNotifier:
                 "Failed to post message to discord (status=%d)", ret.status_code
             )
             if VERBOSE:
-                logger.debug("Send to discord: \n\t%r\nAnd received:\n\t%r",
-                             ret.request.body, ret.text)
+                logger.debug(
+                    "Send to discord: \n\t%r\nAnd received:\n\t%r",
+                    ret.request.body,
+                    ret.text,
+                )
         return ret

--- a/find_star/discord/notifier.py
+++ b/find_star/discord/notifier.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 import requests
 
-from .._constants import EXTERNAL_CONNECTION_TIMEOUT, DEBUG, VERBOSE
+from .._constants import EXTERNAL_CONNECTION_TIMEOUT, DEBUG
 from .._constants.discord import DISCORD_MESSAGE_SPEC
 
 if TYPE_CHECKING:
@@ -93,7 +93,7 @@ class DiscordNotifier:
             logger.error(
                 "Failed to post message to discord (status=%d)", ret.status_code
             )
-            if VERBOSE:
+            if DEBUG:
                 logger.debug(
                     "Send to discord: \n\t%r\nAnd received:\n\t%r",
                     ret.request.body,

--- a/find_star/discord/notifier.py
+++ b/find_star/discord/notifier.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 import requests
 
 from .._constants import EXTERNAL_CONNECTION_TIMEOUT, DEBUG
-from .._constants.discord import DISCORD_MESSAGE_SPEC
+from .._constants.discord import DISCORD_WEBHOOK_PAYLOAD
 
 if TYPE_CHECKING:
     from typing import Dict, Any
@@ -44,19 +44,7 @@ class DiscordNotifier:
     """
 
     headers: "Dict[str, str]" = {"Content-Type": "application/json"}
-    payload: "Dict[str, Any]" = {
-        "username": "OSRS Star Watcher",
-        "content": DISCORD_MESSAGE_SPEC,  # Will be formatted when posting to Discord
-        "embeds": [
-            {
-                "title": "OSRS Star Tracker",
-                "url": "https://osrsportal.com/shooting-stars-tracker",
-                "footer": {
-                    "text": "No affiliation",
-                },
-            },
-        ],
-    }
+    payload: "Dict[str, Any]" = DISCORD_WEBHOOK_PAYLOAD
 
     __endpoint: str
 
@@ -71,6 +59,8 @@ class DiscordNotifier:
         __endpoint: str
             Discord webhook 'uri'
         """
+        if not __endpoint:
+            raise ValueError("Missing Discord webhook endpoint")
         self.__endpoint = __endpoint
 
     def __call__(self, __star_info: "Star") -> "requests.Response":
@@ -78,7 +68,7 @@ class DiscordNotifier:
         star = __star_info
         payload = copy(self.payload)
         payload["content"] = (
-            # Format tempate message with star info
+            # Format template message with star info
             payload["content"].format(**star)
         )
         if DEBUG:


### PR DESCRIPTION
Made converting the datetime object to Unix time the responsibility of the formatter rather than doing it before:

> Done with `{time:%s}` datetime formatting, which for some reason is not documented in the [datetime docs](https://docs.python.org/3/library/datetime.html#format-codes))